### PR TITLE
Remove unused particlesJS global directive

### DIFF
--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -51,9 +51,6 @@
 </template>
 
 <script>
-// Declare particlesJS as a global variable for ESLint
-/* global particlesJS */
-
 import AppBar from "./components/AppBar.vue";
 import FooterBar from "./components/FooterBar.vue";
 import { mapState } from "vuex";


### PR DESCRIPTION
## Summary
- remove the particlesJS global directive comment from App.vue now that the global is referenced directly

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cf211b0050832c8111a27f17562131