### PR TITLE
Update particle colors on theme toggle

### DIFF
--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -51,9 +51,6 @@
 </template>
 
 <script>
-// Declare particlesJS as a global variable for ESLint
-/* global particlesJS */
-
 import AppBar from "./components/AppBar.vue";
 import FooterBar from "./components/FooterBar.vue";
 import { mapState } from "vuex";
@@ -87,123 +84,202 @@ export default {
         this.snackbar = false;
       }, this.snackbarShowTime);
     },
+    getParticlesColor() {
+      const theme = this.$vuetify?.theme;
+      const colorFromTheme = theme?.global?.current?.value?.colors?.particles;
+      if (colorFromTheme) {
+        return colorFromTheme;
+      }
+      if (typeof window !== "undefined") {
+        const rawCssColor = getComputedStyle(document.documentElement).getPropertyValue(
+          "--v-theme-particles"
+        );
+        const normalized = this.normalizeCssRgbColor(rawCssColor);
+        if (normalized) {
+          return normalized;
+        }
+      }
+      return "#000000";
+    },
+    normalizeCssRgbColor(value) {
+      if (!value) {
+        return null;
+      }
+      const components = value
+        .split(",")
+        .map((part) => Number(part.trim()))
+        .filter((num) => !Number.isNaN(num));
+      if (components.length !== 3) {
+        return null;
+      }
+      return `#${components
+        .map((num) => Math.max(0, Math.min(255, num)).toString(16).padStart(2, "0"))
+        .join("")}`;
+    },
+    createParticlesConfig(color) {
+      return {
+        particles: {
+          number: {
+            value: 355,
+            density: {
+              enable: true,
+              value_area: 789.1476416322727,
+            },
+          },
+          color: {
+            value: color,
+          },
+          shape: {
+            type: "circle",
+            stroke: {
+              width: 0,
+              color,
+            },
+            polygon: {
+              nb_sides: 5,
+            },
+            image: {
+              src: "img/github.svg",
+              width: 100,
+              height: 100,
+            },
+          },
+          opacity: {
+            value: 0.48927153781200905,
+            random: false,
+            anim: {
+              enable: true,
+              speed: 0.2,
+              opacity_min: 0,
+              sync: false,
+            },
+          },
+          size: {
+            value: 2,
+            random: true,
+            anim: {
+              enable: true,
+              speed: 2,
+              size_min: 0,
+              sync: false,
+            },
+          },
+          line_linked: {
+            enable: false,
+            distance: 150,
+            color: "#ffffff",
+            opacity: 0.4,
+            width: 1,
+          },
+          move: {
+            enable: true,
+            speed: 0.2,
+            direction: "none",
+            random: true,
+            straight: false,
+            out_mode: "out",
+            bounce: false,
+            attract: {
+              enable: false,
+              rotateX: 600,
+              rotateY: 1200,
+            },
+          },
+        },
+        interactivity: {
+          detect_on: "canvas",
+          events: {
+            onhover: {
+              enable: true,
+              mode: "bubble",
+            },
+            onclick: {
+              enable: true,
+              mode: "push",
+            },
+            resize: true,
+          },
+          modes: {
+            grab: {
+              distance: 400,
+              line_linked: {
+                opacity: 1,
+              },
+            },
+            bubble: {
+              distance: 83.91608391608392,
+              size: 1,
+              duration: 3,
+              opacity: 1,
+              speed: 3,
+            },
+            repulse: {
+              distance: 200,
+              duration: 0.4,
+            },
+            push: {
+              particles_nb: 4,
+            },
+            remove: {
+              particles_nb: 2,
+            },
+          },
+        },
+        retina_detect: true,
+      };
+    },
+    refreshParticles() {
+      if (typeof window === "undefined" || typeof window.particlesJS !== "function") {
+        return;
+      }
+      const color = this.getParticlesColor();
+      if (Array.isArray(window.pJSDom) && window.pJSDom.length) {
+        window.pJSDom.forEach((instance) => {
+          instance?.pJS?.fn?.vendors?.destroypJS?.();
+        });
+        window.pJSDom = [];
+      }
+      window.particlesJS("particles-js", this.createParticlesConfig(color));
+    },
     loadParticlesJS() {
+      if (typeof window === "undefined") {
+        return;
+      }
+      if (typeof window.particlesJS === "function") {
+        this.refreshParticles();
+        return;
+      }
+      const existingScript = document.querySelector("script[data-particles]");
+      if (existingScript) {
+        existingScript.addEventListener(
+          "load",
+          () => {
+            this.refreshParticles();
+          },
+          { once: true }
+        );
+        return;
+      }
       const script = document.createElement("script");
       script.src =
         "https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js";
+      script.dataset.particles = "true";
       script.onload = () => {
-        particlesJS("particles-js", {
-          particles: {
-            number: {
-              value: 355,
-              density: {
-                enable: true,
-                value_area: 789.1476416322727,
-              },
-            },
-            color: {
-              value: "#000000",
-            },
-            shape: {
-              type: "circle",
-              stroke: {
-                width: 0,
-                color: "#000000",
-              },
-              polygon: {
-                nb_sides: 5,
-              },
-              image: {
-                src: "img/github.svg",
-                width: 100,
-                height: 100,
-              },
-            },
-            opacity: {
-              value: 0.48927153781200905,
-              random: false,
-              anim: {
-                enable: true,
-                speed: 0.2,
-                opacity_min: 0,
-                sync: false,
-              },
-            },
-            size: {
-              value: 2,
-              random: true,
-              anim: {
-                enable: true,
-                speed: 2,
-                size_min: 0,
-                sync: false,
-              },
-            },
-            line_linked: {
-              enable: false,
-              distance: 150,
-              color: "#ffffff",
-              opacity: 0.4,
-              width: 1,
-            },
-            move: {
-              enable: true,
-              speed: 0.2,
-              direction: "none",
-              random: true,
-              straight: false,
-              out_mode: "out",
-              bounce: false,
-              attract: {
-                enable: false,
-                rotateX: 600,
-                rotateY: 1200,
-              },
-            },
-          },
-          interactivity: {
-            detect_on: "canvas",
-            events: {
-              onhover: {
-                enable: true,
-                mode: "bubble",
-              },
-              onclick: {
-                enable: true,
-                mode: "push",
-              },
-              resize: true,
-            },
-            modes: {
-              grab: {
-                distance: 400,
-                line_linked: {
-                  opacity: 1,
-                },
-              },
-              bubble: {
-                distance: 83.91608391608392,
-                size: 1,
-                duration: 3,
-                opacity: 1,
-                speed: 3,
-              },
-              repulse: {
-                distance: 200,
-                duration: 0.4,
-              },
-              push: {
-                particles_nb: 4,
-              },
-              remove: {
-                particles_nb: 2,
-              },
-            },
-          },
-          retina_detect: true,
-        });
+        this.refreshParticles();
       };
       document.head.appendChild(script);
+    },
+    toggleTheme() {
+      this.$nextTick(() => {
+        if (typeof window === "undefined") {
+          return;
+        }
+        if (typeof window.particlesJS === "function") {
+          this.refreshParticles();
+        } else {
+          this.loadParticlesJS();
+        }
+      });
     },
   },
   mounted() {

--- a/website/src/components/AppBar.vue
+++ b/website/src/components/AppBar.vue
@@ -347,7 +347,7 @@ import { useStore } from "vuex";
 
 export default {
   name: "AppBar",
-  setup() {
+  setup(_, { emit }) {
     const store = useStore();
     const theme = useTheme();
     const router = useRouter();
@@ -370,6 +370,7 @@ export default {
       theme.global.name.value = theme.global.current.value.dark
         ? "light"
         : "dark";
+      emit("toggle-theme");
     }
     function updateIsDark() {
       isDark.value = theme.global.name.value !== "dark";


### PR DESCRIPTION
## Summary
- emit the toggle-theme event from the AppBar after switching Vuetify themes
- refresh the particles.js canvas with the active theme color when the theme changes
- centralize particle initialization so both mount and theme toggles use theme-derived colors
- fall back to the CSS particle color variable when the theme object lacks an updated value so dots stay visible on dark backgrounds

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68cf111fd7b0832ca765ab9d30d38b41