### PR TITLE
Improve SEO metadata and media loading

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -8,6 +8,41 @@
     <title><%= htmlWebpackPlugin.options.title %></title> -->
     <link rel="icon" type="image" href="/favicon.ico" />
     <title>Bobagi</title>
+    <meta
+      name="description"
+      content="Bobagi showcases automation tools, game servers, and development projects crafted by Gustavo Aperin."
+    />
+    <meta property="og:title" content="Bobagi" />
+    <meta
+      property="og:description"
+      content="Explore Bobagi's automation bots, gaming utilities, and engineering projects."
+    />
+    <meta property="og:image" content="https://bobagi.net/bobagiCursive.png" />
+    <meta property="og:url" content="https://bobagi.net" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Bobagi" />
+    <meta
+      name="twitter:description"
+      content="Automation tools, game servers, and development projects by Bobagi."
+    />
+    <meta name="twitter:image" content="https://bobagi.net/bobagiCursive.png" />
+    <link rel="canonical" href="https://bobagi.net" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "Bobagi",
+        "url": "https://bobagi.net",
+        "logo": "https://bobagi.net/bobagiCursive.png",
+        "sameAs": [
+          "https://github.com/Bobagi",
+          "https://www.linkedin.com/in/gustavoaperin/",
+          "https://www.youtube.com/@Bobagi"
+        ],
+        "description": "Automation bots, gaming utilities, and software projects crafted by Gustavo Aperin."
+      }
+    </script>
   </head>
   <body>
     <noscript>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -37,8 +37,7 @@
         "logo": "https://bobagi.net/bobagiCursive.png",
         "sameAs": [
           "https://github.com/Bobagi",
-          "https://www.linkedin.com/in/gustavoaperin/",
-          "https://www.youtube.com/@Bobagi"
+          "https://www.linkedin.com/in/gustavoaperin/"
         ],
         "description": "Automation bots, gaming utilities, and software projects crafted by Gustavo Aperin."
       }

--- a/website/src/components/FooterBar.vue
+++ b/website/src/components/FooterBar.vue
@@ -13,9 +13,40 @@
         <v-col
           style="padding: 0; gap: 15px; justify-content: right; display: flex"
         >
-          <p id="lastUpdatedLabel" class="betweenLines" style="align-self: end" tooltip="45.179.91.168">
-            last update: {{ lastCommitDate }}
-          </p>
+          <div class="d-flex align-end" style="gap: 8px">
+            <p id="lastUpdatedLabel" class="betweenLines" style="align-self: end" tooltip="45.179.91.168">
+              last update: {{ lastCommitDate }}
+            </p>
+            <div class="d-flex" style="gap: 8px">
+              <v-btn
+                icon
+                size="small"
+                :href="socialLinks.github"
+                target="_blank"
+                aria-label="GitHub"
+              >
+                <v-icon icon="mdi-github"></v-icon>
+              </v-btn>
+              <v-btn
+                icon
+                size="small"
+                :href="socialLinks.linkedin"
+                target="_blank"
+                aria-label="LinkedIn"
+              >
+                <v-icon icon="mdi-linkedin"></v-icon>
+              </v-btn>
+              <v-btn
+                icon
+                size="small"
+                :href="socialLinks.youtube"
+                target="_blank"
+                aria-label="YouTube"
+              >
+                <v-icon icon="mdi-youtube"></v-icon>
+              </v-btn>
+            </div>
+          </div>
           <a href="https://www.linkedin.com/in/gustavoaperin/" target="_blank">
             <v-img
               :width="50"
@@ -24,7 +55,8 @@
               src="/bobagiCursive.png"
               alt="Bobagi wrote in a fancy hand-draw style"
               class="logo"
-            ></v-img
+              :loading="'lazy'"
+            ></v-img>
           ></a>
         </v-col>
       </v-row>
@@ -38,6 +70,11 @@ export default {
   data() {
     return {
       lastCommitDate: null,
+      socialLinks: {
+        github: "https://github.com/Bobagi",
+        linkedin: "https://www.linkedin.com/in/gustavoaperin/",
+        youtube: "https://www.youtube.com/@Bobagi",
+      },
     };
   },
   computed: {

--- a/website/src/components/FooterBar.vue
+++ b/website/src/components/FooterBar.vue
@@ -36,15 +36,6 @@
               >
                 <v-icon icon="mdi-linkedin"></v-icon>
               </v-btn>
-              <v-btn
-                icon
-                size="small"
-                :href="socialLinks.youtube"
-                target="_blank"
-                aria-label="YouTube"
-              >
-                <v-icon icon="mdi-youtube"></v-icon>
-              </v-btn>
             </div>
           </div>
           <a href="https://www.linkedin.com/in/gustavoaperin/" target="_blank">
@@ -57,7 +48,7 @@
               class="logo"
               :loading="'lazy'"
             ></v-img>
-          ></a>
+          </a>
         </v-col>
       </v-row>
     </v-container>
@@ -73,7 +64,6 @@ export default {
       socialLinks: {
         github: "https://github.com/Bobagi",
         linkedin: "https://www.linkedin.com/in/gustavoaperin/",
-        youtube: "https://www.youtube.com/@Bobagi",
       },
     };
   },

--- a/website/src/components/HeroWars.vue
+++ b/website/src/components/HeroWars.vue
@@ -8,6 +8,7 @@
             height="100"
             class="logo orange-shadow mb-6"
             alt="Hero Wars logo"
+            :loading="'lazy'"
           />
         </a>
 
@@ -26,6 +27,7 @@
               class="logo"
               style="max-height: 20em"
               alt="Orion sprite"
+              loading="lazy"
             />
           </v-col>
           <v-col cols="12" md="7">

--- a/website/src/components/ProjectZomboid.vue
+++ b/website/src/components/ProjectZomboid.vue
@@ -11,6 +11,7 @@
             height="100"
             class="logo black-shadow mb-6"
             alt="Project Zomboid logo"
+            :loading="'lazy'"
           />
         </a>
 
@@ -31,6 +32,7 @@
               class="logo black-shadow"
               style="max-height: 20em"
               alt="Programmer zombie"
+              loading="lazy"
             />
           </v-col>
           <v-col cols="12" md="7">


### PR DESCRIPTION
## Summary
- add meta description, open graph, twitter tags, and structured data to the main HTML template
- introduce social media links in the footer and mark brand imagery for lazy loading
- enable lazy loading on hero imagery used across feature pages to improve perceived performance

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_6907c7f5ee18832c80eef5bc4313bf10