### PR TITLE
Improve particles visibility and locale selector

### DIFF
--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -169,7 +169,7 @@ export default {
             random: false,
             anim: {
               enable: true,
-              speed: 0.2,
+              speed: 0.05,
               opacity_min: 0,
               sync: false,
             },
@@ -187,18 +187,18 @@ export default {
           line_linked: {
             enable: false,
             distance: 150,
-            color: "#ffffff",
+            color: particleColor,
             opacity: 0.4,
             width: 1,
           },
           move: {
             enable: true,
-            speed: 0.15,
+            speed: 0.2,
             direction: "none",
             random: true,
             straight: false,
-            out_mode: "bounce",
-            bounce: true,
+            out_mode: "out",
+            bounce: false,
             attract: {
               enable: false,
               rotateX: 600,

--- a/website/src/App.vue
+++ b/website/src/App.vue
@@ -20,7 +20,7 @@
       class="particles-bg"
     ></v-sheet>
 
-    <AppBar @toggle-theme="toggleTheme" />
+    <AppBar @toggle-theme="handleThemeToggle" />
 
     <!-- Main content, with responsive margins -->
     <v-main
@@ -70,6 +70,8 @@ export default {
       snackbar: false,
       snackbarMessage: "",
       snackbarShowTime: 4000,
+      particlesScriptLoaded: false,
+      particlesScriptSource: "https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js",
     };
   },
   computed: {
@@ -87,127 +89,178 @@ export default {
         this.snackbar = false;
       }, this.snackbarShowTime);
     },
-    loadParticlesJS() {
-      const script = document.createElement("script");
-      script.src =
-        "https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js";
-      script.onload = () => {
-        particlesJS("particles-js", {
-          particles: {
-            number: {
-              value: 355,
-              density: {
-                enable: true,
-                value_area: 789.1476416322727,
-              },
+    async loadParticlesScript() {
+      if (window.particlesJS || this.particlesScriptLoaded) {
+        return Promise.resolve();
+      }
+
+      const existingScript = document.querySelector(
+        `script[src="${this.particlesScriptSource}"]`
+      );
+
+      if (existingScript) {
+        return new Promise((resolve) => {
+          existingScript.addEventListener("load", () => {
+            this.particlesScriptLoaded = true;
+            resolve();
+          });
+        });
+      }
+
+      return new Promise((resolve) => {
+        const script = document.createElement("script");
+        script.src = this.particlesScriptSource;
+        script.onload = () => {
+          this.particlesScriptLoaded = true;
+          resolve();
+        };
+        document.head.appendChild(script);
+      });
+    },
+    destroyExistingParticles() {
+      if (!window.pJSDom || !window.pJSDom.length) {
+        return;
+      }
+
+      window.pJSDom.forEach((particlesInstance) => {
+        particlesInstance.pJS?.fn?.vendors?.destroypJS();
+      });
+      window.pJSDom = [];
+    },
+    getParticlesColor() {
+      const computedStyle = getComputedStyle(document.documentElement);
+      const themeParticleColor = computedStyle
+        .getPropertyValue("--v-theme-particles")
+        .trim();
+      return themeParticleColor || "#000000";
+    },
+    initializeParticles() {
+      const particleColor = this.getParticlesColor();
+
+      particlesJS("particles-js", {
+        particles: {
+          number: {
+            value: 355,
+            density: {
+              enable: true,
+              value_area: 789.1476416322727,
             },
-            color: {
-              value: "#000000",
+          },
+          color: {
+            value: particleColor,
+          },
+          shape: {
+            type: "circle",
+            stroke: {
+              width: 0,
+              color: particleColor,
             },
-            shape: {
-              type: "circle",
-              stroke: {
-                width: 0,
-                color: "#000000",
-              },
-              polygon: {
-                nb_sides: 5,
-              },
-              image: {
-                src: "img/github.svg",
-                width: 100,
-                height: 100,
-              },
+            polygon: {
+              nb_sides: 5,
             },
-            opacity: {
-              value: 0.48927153781200905,
-              random: false,
-              anim: {
-                enable: true,
-                speed: 0.2,
-                opacity_min: 0,
-                sync: false,
-              },
+            image: {
+              src: "img/github.svg",
+              width: 100,
+              height: 100,
             },
-            size: {
-              value: 2,
-              random: true,
-              anim: {
-                enable: true,
-                speed: 2,
-                size_min: 0,
-                sync: false,
-              },
-            },
-            line_linked: {
-              enable: false,
-              distance: 150,
-              color: "#ffffff",
-              opacity: 0.4,
-              width: 1,
-            },
-            move: {
+          },
+          opacity: {
+            value: 0.48927153781200905,
+            random: false,
+            anim: {
               enable: true,
               speed: 0.2,
-              direction: "none",
-              random: true,
-              straight: false,
-              out_mode: "out",
-              bounce: false,
-              attract: {
-                enable: false,
-                rotateX: 600,
-                rotateY: 1200,
-              },
+              opacity_min: 0,
+              sync: false,
             },
           },
-          interactivity: {
-            detect_on: "canvas",
-            events: {
-              onhover: {
-                enable: true,
-                mode: "bubble",
-              },
-              onclick: {
-                enable: true,
-                mode: "push",
-              },
-              resize: true,
+          size: {
+            value: 2,
+            random: true,
+            anim: {
+              enable: true,
+              speed: 2,
+              size_min: 0,
+              sync: false,
             },
-            modes: {
-              grab: {
-                distance: 400,
-                line_linked: {
-                  opacity: 1,
-                },
-              },
-              bubble: {
-                distance: 83.91608391608392,
-                size: 1,
-                duration: 3,
+          },
+          line_linked: {
+            enable: false,
+            distance: 150,
+            color: "#ffffff",
+            opacity: 0.4,
+            width: 1,
+          },
+          move: {
+            enable: true,
+            speed: 0.15,
+            direction: "none",
+            random: true,
+            straight: false,
+            out_mode: "bounce",
+            bounce: true,
+            attract: {
+              enable: false,
+              rotateX: 600,
+              rotateY: 1200,
+            },
+          },
+        },
+        interactivity: {
+          detect_on: "canvas",
+          events: {
+            onhover: {
+              enable: true,
+              mode: "bubble",
+            },
+            onclick: {
+              enable: true,
+              mode: "push",
+            },
+            resize: true,
+          },
+          modes: {
+            grab: {
+              distance: 400,
+              line_linked: {
                 opacity: 1,
-                speed: 3,
-              },
-              repulse: {
-                distance: 200,
-                duration: 0.4,
-              },
-              push: {
-                particles_nb: 4,
-              },
-              remove: {
-                particles_nb: 2,
               },
             },
+            bubble: {
+              distance: 83.91608391608392,
+              size: 1,
+              duration: 3,
+              opacity: 1,
+              speed: 3,
+            },
+            repulse: {
+              distance: 200,
+              duration: 0.4,
+            },
+            push: {
+              particles_nb: 4,
+            },
+            remove: {
+              particles_nb: 2,
+            },
           },
-          retina_detect: true,
-        });
-      };
-      document.head.appendChild(script);
+        },
+        retina_detect: true,
+      });
+    },
+    async refreshParticles() {
+      await this.loadParticlesScript();
+      this.destroyExistingParticles();
+      this.initializeParticles();
+    },
+    handleThemeToggle() {
+      this.$nextTick(() => {
+        this.refreshParticles();
+      });
     },
   },
   mounted() {
-    this.loadParticlesJS();
+    this.refreshParticles();
   },
 };
 </script>

--- a/website/src/components/AppBar.vue
+++ b/website/src/components/AppBar.vue
@@ -124,7 +124,7 @@
       <v-select
         v-model="selectedLocale"
         :items="locales"
-        item-title="emoji"
+        item-title="label"
         item-value="code"
         color="primary"
         hide-details
@@ -266,7 +266,7 @@
       <v-select
         v-model="selectedLocale"
         :items="locales"
-        item-title="emoji"
+        item-title="label"
         item-value="code"
         color="primary"
         hide-details
@@ -334,11 +334,12 @@
 
 .auto-width {
   display: inline-block;
-  max-width: 79px !important;
+  max-width: 140px !important;
 }
 </style>
 
 <script>
+import { defineEmits } from "vue";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
@@ -351,6 +352,7 @@ export default {
     const store = useStore();
     const theme = useTheme();
     const router = useRouter();
+    const emit = defineEmits(["toggle-theme"]);
     const isDark = ref(false);
     const user = computed(() => store.state.user);
     const { locale } = useI18n();
@@ -359,12 +361,13 @@ export default {
       locale.value = newLocale;
     });
     const locales = [
-      { code: "en", emoji: "🇺🇸" },
-      { code: "pt", emoji: "🇧🇷" },
+      { code: "en", label: "🇺🇸 English" },
+      { code: "pt", label: "🇧🇷 Português" },
     ];
     function toggleIcon() {
       toggleTheme();
       updateIsDark();
+      emit("toggle-theme", theme.global.name.value);
     }
     function toggleTheme() {
       theme.global.name.value = theme.global.current.value.dark
@@ -372,12 +375,13 @@ export default {
         : "dark";
     }
     function updateIsDark() {
-      isDark.value = theme.global.name.value !== "dark";
+      isDark.value = theme.global.current.value.dark;
     }
     function disconnectUser() {
       store.dispatch("logout");
       router.push("/");
     }
+    updateIsDark();
     return {
       user,
       isDark,

--- a/website/src/components/AppBar.vue
+++ b/website/src/components/AppBar.vue
@@ -124,17 +124,34 @@
       <v-select
         v-model="selectedLocale"
         :items="locales"
-        item-title="label"
+        item-title="labelWithFlag"
         item-value="code"
         color="primary"
         hide-details
         variant="text"
         class="auto-width"
-      ></v-select>
+      >
+        <template #selection="{ item }">
+          <div class="locale-option">
+            <span class="locale-flag">{{ item.raw.flagEmoji }}</span>
+            <span class="locale-label">{{ item.raw.label }}</span>
+          </div>
+        </template>
+        <template #item="{ item, props }">
+          <v-list-item v-bind="props">
+            <v-list-item-title>
+              <div class="locale-option">
+                <span class="locale-flag">{{ item.raw.flagEmoji }}</span>
+                <span class="locale-label">{{ item.raw.label }}</span>
+              </div>
+            </v-list-item-title>
+          </v-list-item>
+        </template>
+      </v-select>
 
       <v-btn
         icon
-        @click="toggleIcon"
+        @click="handleThemeToggleClick"
         class="mr-2"
       >
         <v-icon color="primary">{{ isDark ? 'mdi-weather-night' : 'mdi-weather-sunny' }}</v-icon>
@@ -175,7 +192,7 @@
         height="100%"
         color="primary"
         prepend-icon="mdi-logout"
-        @click="disconnectUser"
+        @click="disconnectCurrentUser"
       >
         Disconnect
       </v-btn>
@@ -261,22 +278,39 @@
           </v-list-item>
         </v-list>
       </v-menu>
-      <v-spacer></v-spacer>
+        <v-spacer></v-spacer>
 
-      <v-select
-        v-model="selectedLocale"
-        :items="locales"
-        item-title="label"
-        item-value="code"
-        color="primary"
-        hide-details
-        variant="text"
-        class="auto-width"
-      ></v-select>
+        <v-select
+          v-model="selectedLocale"
+          :items="locales"
+          item-title="labelWithFlag"
+          item-value="code"
+          color="primary"
+          hide-details
+          variant="text"
+          class="auto-width"
+        >
+          <template #selection="{ item }">
+            <div class="locale-option">
+              <span class="locale-flag">{{ item.raw.flagEmoji }}</span>
+              <span class="locale-label">{{ item.raw.label }}</span>
+            </div>
+          </template>
+          <template #item="{ item, props }">
+            <v-list-item v-bind="props">
+              <v-list-item-title>
+                <div class="locale-option">
+                  <span class="locale-flag">{{ item.raw.flagEmoji }}</span>
+                  <span class="locale-label">{{ item.raw.label }}</span>
+                </div>
+              </v-list-item-title>
+            </v-list-item>
+          </template>
+        </v-select>
 
       <v-btn
         icon
-        @click="toggleIcon"
+        @click="handleThemeToggleClick"
         class="mr-2"
       >
         <v-icon color="primary">{{ isDark ? 'mdi-weather-night' : 'mdi-weather-sunny' }}</v-icon>
@@ -318,7 +352,7 @@
         height="100%"
         color="primary"
         prepend-icon="mdi-logout"
-        @click="disconnectUser"
+        @click="disconnectCurrentUser"
       >
         Disconnect
       </v-btn>
@@ -336,60 +370,77 @@
   display: inline-block;
   max-width: 140px !important;
 }
+
+.locale-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.locale-flag {
+  font-size: 16px;
+}
+
+.locale-label {
+  font-size: 14px;
+}
 </style>
 
 <script>
-import { defineEmits } from "vue";
-import { computed, ref, watch } from "vue";
+import { computed, defineComponent, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import { useTheme } from "vuetify";
 import { useStore } from "vuex";
 
-export default {
+export default defineComponent({
   name: "AppBar",
-  setup() {
-    const store = useStore();
-    const theme = useTheme();
-    const router = useRouter();
-    const emit = defineEmits(["toggle-theme"]);
-    const isDark = ref(false);
-    const user = computed(() => store.state.user);
+  setup(props, { emit }) {
+    const vuexStore = useStore();
+    const vuetifyTheme = useTheme();
+    const vueRouter = useRouter();
     const { locale } = useI18n();
+    const isDark = ref(vuetifyTheme.global.current.value.dark);
+    const user = computed(() => vuexStore.state.user);
+    const locales = [
+      { code: "en", label: "English", labelWithFlag: "🇺🇸 English", flagEmoji: "🇺🇸" },
+      { code: "pt", label: "Português", labelWithFlag: "🇧🇷 Português", flagEmoji: "🇧🇷" },
+    ];
     const selectedLocale = ref(locale.value);
+
     watch(selectedLocale, (newLocale) => {
       locale.value = newLocale;
     });
-    const locales = [
-      { code: "en", label: "🇺🇸 English" },
-      { code: "pt", label: "🇧🇷 Português" },
-    ];
-    function toggleIcon() {
-      toggleTheme();
-      updateIsDark();
-      emit("toggle-theme", theme.global.name.value);
+
+    function updateIsDarkFromTheme() {
+      isDark.value = vuetifyTheme.global.current.value.dark;
     }
-    function toggleTheme() {
-      theme.global.name.value = theme.global.current.value.dark
+
+    function toggleThemeVariant() {
+      vuetifyTheme.global.name.value = vuetifyTheme.global.current.value.dark
         ? "light"
         : "dark";
     }
-    function updateIsDark() {
-      isDark.value = theme.global.current.value.dark;
+
+    function handleThemeToggleClick() {
+      toggleThemeVariant();
+      updateIsDarkFromTheme();
+      emit("toggle-theme", vuetifyTheme.global.name.value);
     }
-    function disconnectUser() {
-      store.dispatch("logout");
-      router.push("/");
+
+    function disconnectCurrentUser() {
+      vuexStore.dispatch("logout");
+      vueRouter.push("/");
     }
-    updateIsDark();
+
     return {
       user,
       isDark,
-      toggleIcon,
-      disconnectUser,
       selectedLocale,
       locales,
+      handleThemeToggleClick,
+      disconnectCurrentUser,
     };
   },
-};
+});
 </script>

--- a/website/src/plugins/vuetify.js
+++ b/website/src/plugins/vuetify.js
@@ -51,7 +51,7 @@ export default createVuetify({
         colors: {
           background: "#F2F2F2",
           content: "#F2F2F2",
-          contentbg: "#000000",
+          contentbg: "#F2F2F2",
           surface: "#000000",
           primary: "#000000",
           "primary-darken-1": "#3700B3",

--- a/website/src/plugins/vuetify.js
+++ b/website/src/plugins/vuetify.js
@@ -25,7 +25,7 @@ export default createVuetify({
           info: "#2196F3",
           success: "#4CAF50",
           warning: "#FB8C00",
-          particles: "#000000",
+          particles: "#FFFFFF",
         },
       },
       darkGreen: {
@@ -44,7 +44,7 @@ export default createVuetify({
           info: "#2196F3",
           success: "#4CAF50",
           warning: "#FB8C00",
-          particles: "#000000",
+          particles: "#FFFFFF",
         },
       },
       light: {
@@ -62,7 +62,7 @@ export default createVuetify({
           info: "#2196F3",
           success: "#4CAF50",
           warning: "#FB8C00",
-          particles: "#F2F2F2",
+          particles: "#000000",
         },
       },
     },


### PR DESCRIPTION
## Summary
- refresh particles with theme-aware colors and longer on-screen movement
- reset particles when toggling themes so dark mode uses visible white particles
- show language options with flag labels in the locale selector

## Testing
- Not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693400c0ed8c832caea873907af3bc86)