### PR TITLE
ci: fix deploy by using --legacy-peer-deps

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies and build site
         run: |
           set -e
-          npm install
+          npm install --legacy-peer-deps
           npm run build
 
       - name: Deploy to VPS - Develop Environment
@@ -42,5 +42,5 @@ jobs:
             cd /var/www/develop/Bobagi-Website
             git reset --hard
             git pull origin develop
-            npm install
+            npm install --legacy-peer-deps
             npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies and build site
         run: |
           set -e
-          npm install
+          npm install --legacy-peer-deps
           npm run build
 
       - name: Deploy to VPS - Production Environment
@@ -42,5 +42,5 @@ jobs:
             cd /var/www/Bobagi-Website
             git reset --hard
             git pull origin main
-            npm install
+            npm install --legacy-peer-deps
             npm run build


### PR DESCRIPTION
Every `Deploy to VPS` run has failed for months: a clean `npm install` hits `ERESOLVE` because `vuetify@3.12.8` wants `webpack-plugin-vuetify >=3.1.0` while the project pins `2.0.1`.

Verified in a clean dir: plain `npm install` exits 1 (ERESOLVE); `npm install --legacy-peer-deps` exits 0. This adds `--legacy-peer-deps` to the CI build step and the VPS SSH deploy script in both the production and develop workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)