### PR TITLE
chore: drop /ChatTrainer from SEO index files

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -19,7 +19,6 @@ each with its own page and, in most cases, a live demo or download.
 - Project Zomboid server: https://bobagi.space/ProjectZomboid
 - Godot Game (Dracomania): https://bobagi.space/GodotGame
 - One Way Fly: https://bobagi.space/OneWayFly
-- Chat Trainer: https://bobagi.space/ChatTrainer
 - Snowflake: https://bobagi.space/Snowflake
 
 ## Author

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -46,11 +46,6 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://bobagi.space/ChatTrainer</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://bobagi.space/Snowflake</loc>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>


### PR DESCRIPTION
Follow-up to #63: removes the now-404 `/ChatTrainer` entry from `public/llms.txt` and `public/sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)